### PR TITLE
fix Clang 3.6 - 7.0 undefined reference bug

### DIFF
--- a/cli/cli.h
+++ b/cli/cli.h
@@ -772,7 +772,7 @@ namespace cli
             std::remove_if(
                 strs.begin(),
                 strs.end(),
-                std::bind( &std::string::empty, std::placeholders::_1 )
+                [](const std::string& s){ return s.empty(); }
             ),
             strs.end()
         );
@@ -851,4 +851,3 @@ namespace cli
 } // namespace
 
 #endif
-


### PR DESCRIPTION
Turns out using `std::bind(&std::string::empty` prevents Clang from building a `complete.cpp` example and using `CliTelnetServer` in my code.

There is apparently a compiler bug in Clang since 3.6 that appears to be fixed only in 8.0. It manifests as `undefined reference to xxx` when accessing `xxx` as `&templated_class::xxx`. Here is a [minimal example](https://wandbox.org/permlink/QANPZsqxWaztiifh) (can be fixed by either turning optimizations on, or by declaring `template class std::basic_string<char>;`).