### PR TITLE
bug: infinite loop on EoF

### DIFF
--- a/cli/clifilesession.h
+++ b/cli/clifilesession.h
@@ -54,11 +54,13 @@ public:
     }
     void Start()
     {
-        while( !exit)
+        while( !( exit || in.eof() ))
         {
             session.Prompt();
             std::string line;
             std::getline(in, line);
+            if(in.eof())
+              line = "exit";
             session.Feed( line );
         }
     }


### PR DESCRIPTION
Hello,

With the simplelocalsession sample, if one presses Ctrl-D (the *nix way to end a session), the program goes into an infinite loop. So I added a test on in.eof() in the while condition.

The `line = "exit"` part is a bit dirty but this allows the exit methods to be called.
A cleaner solution could be to add an `ExitAll` method to Session; or store the `cli` instance ref. in CliFileSession. I prefer the former…

Bye
M.