### PR TITLE
Fix teardown race condition

### DIFF
--- a/cli/cli.h
+++ b/cli/cli.h
@@ -205,13 +205,11 @@ namespace cli
 
         void Help() const;
 
-        void Exit()
+        virtual void Exit()
         {
             exiting = true;
             if (exitAction) exitAction(out);
             cli.ExitAction(out);
-            // Close stdin to abort getchar() and allow the keyboard listener to destroy
-            fclose(stdin);
         }
 
         void ExitAction( std::function< void(std::ostream&)> action )

--- a/cli/clilocalsession.h
+++ b/cli/clilocalsession.h
@@ -43,8 +43,8 @@ class CliLocalTerminalSession : public CliSession
 private:
     int makeShutdownPipe()
     {
-#if defined(OS_LINUX) || defined(OS_MAC)
-        int fds[2]
+#if defined(CLI_OS_LINUX) || defined(CLI_OS_MAC)
+		int fds[2];
         if (pipe(fds) == 0) {
             // We store the write end
             shutdownPipe = fds[1];
@@ -65,18 +65,20 @@ public:
         Prompt();
     }
 
-    virtual Exit()
+    virtual void Exit()
     {
         CliSession::Exit();
-#if defined(OS_LINUX) || defined(OS_MAC)
+#if defined(CLI_OS_LINUX) || defined(CLI_OS_MAC)
         write(shutdownPipe, " ", 1);
+		close(shutdownPipe);
+		shutdownPipe = -1;
 #endif
     }
 
 private:
     Keyboard kb;
     InputHandler ih;
-#if defined(OS_LINUX) || defined(OS_MAC)
+#if defined(CLI_OS_LINUX) || defined(CLI_OS_MAC)
     int shutdownPipe;
 #endif
 };

--- a/cli/keyboard.h
+++ b/cli/keyboard.h
@@ -31,18 +31,24 @@
 #define KEYBOARD_H_
 
 #if defined(__unix__) || defined(__unix) || defined(__linux__)
-#define OS_LINUX
+    #ifndef CLI_OS_LINUX
+    #define CLI_OS_LINUX
+    #endif
 #elif defined(WIN32) || defined(_WIN32) || defined(_WIN64)
-#define OS_WIN
+    #ifndef CLI_OS_WIN
+    #define CLI_OS_WIN
+    #endif
 #elif defined(__APPLE__) || defined(__MACH__)
-#define OS_MAC
+    #ifndef CLI_OS_MAC
+    #define CLI_OS_MAC
+    #endif
 #else
-#error Unknown Platform
+    #error Unknown Platform
 #endif
 
-#if defined(OS_LINUX) || defined(OS_MAC)
+#if defined(CLI_OS_LINUX) || defined(CLI_OS_MAC)
     #include "linuxkeyboard.h"
-#elif defined(OS_WIN)
+#elif defined(CLI_OS_WIN)
 	#include "winkeyboard.h"
 #else
     #error "Platform not supported (yet)."
@@ -50,19 +56,15 @@
 
 namespace cli
 {
-#if defined(OS_LINUX) || defined(OS_MAC)
+#if defined(CLI_OS_LINUX) || defined(CLI_OS_MAC)
     using Keyboard = LinuxKeyboard;
-#elif defined(OS_WIN)
+#elif defined(CLI_OS_WIN)
 	using Keyboard = WinKeyboard;
 #else
     #error "Platform not supported (yet)."
 #endif
 
 } // namespace
-
-#undef OS_LINUX
-#undef OS_WIN
-#undef OS_MAC
 
 #endif // KEYBOARD_H_
 

--- a/cli/linuxkeyboard.h
+++ b/cli/linuxkeyboard.h
@@ -52,8 +52,7 @@ class LinuxKeyboard : public InputDevice
 public:
     explicit LinuxKeyboard(boost::asio::io_service& ios, int shutdownPipe) :
         InputDevice(ios),
-        shutdownPipe(shutdownPipe),
-        servant{ [this](){ Read(); } }
+        shutdownPipe(shutdownPipe)
     {
         ToManualMode();
     }
@@ -68,7 +67,7 @@ public:
 
 private:
 
-    void Read()
+    void Read() noexcept
     {
         while ( run )
         {
@@ -166,7 +165,9 @@ private:
     termios oldt;
     termios newt;
     std::atomic<bool> run{ true };
-    std::thread servant;
+    std::thread servant{ [this]() noexcept {
+        Read();
+    }};
 };
 
 } // namespace

--- a/cli/winkeyboard.h
+++ b/cli/winkeyboard.h
@@ -47,8 +47,7 @@ namespace cli
 class WinKeyboard : public InputDevice
 {
 public:
-    explicit WinKeyboard(boost::asio::io_service &ios, int) : InputDevice(ios),
-        servant{ [this](){ Read(); } }
+    explicit WinKeyboard(boost::asio::io_service &ios, int) : InputDevice(ios)
     {
 
     }
@@ -61,7 +60,7 @@ public:
     }
 
 private:
-    void Read()
+    void Read() noexcept
     {
         while (run)
         {
@@ -119,7 +118,9 @@ private:
     }
 
     std::atomic<bool> run{true};
-    std::thread servant;
+    std::thread servant{ [this]() noexcept {
+        Read();
+    }};
 };
 
 } // namespace

--- a/cli/winkeyboard.h
+++ b/cli/winkeyboard.h
@@ -47,7 +47,7 @@ namespace cli
 class WinKeyboard : public InputDevice
 {
 public:
-    explicit WinKeyboard(boost::asio::io_service &ios) : InputDevice(ios),
+    explicit WinKeyboard(boost::asio::io_service &ios, int) : InputDevice(ios),
         servant{ [this](){ Read(); } }
     {
 

--- a/cli/winkeyboard.h
+++ b/cli/winkeyboard.h
@@ -47,14 +47,17 @@ namespace cli
 class WinKeyboard : public InputDevice
 {
 public:
-    explicit WinKeyboard(boost::asio::io_service &ios) : InputDevice(ios)
+    explicit WinKeyboard(boost::asio::io_service &ios) : InputDevice(ios),
+        servant{ [this](){ Read(); } }
     {
-        servant = std::make_unique<std::thread>([this]() { Read(); });
-        servant->detach();
+
     }
     ~WinKeyboard()
     {
         run = false;
+        if (servant.joinable()) {
+            servant.join();
+        }
     }
 
 private:
@@ -116,7 +119,7 @@ private:
     }
 
     std::atomic<bool> run{true};
-    std::unique_ptr<std::thread> servant;
+    std::thread servant;
 };
 
 } // namespace


### PR DESCRIPTION
The keyboard listeners used in a CLI session don't have safe destruction patterns. The most obvious issue is that the atomic_bools used to track whether the listener is running can be destroyed before the thread reading them exits. The thread ownership pattern is also incorrect, as you shouldn't be both detaching and retaining a thread object.

On POSIX, a special pipe is passed to the keyboard listener which allows it to receive a signal from the CliSession when the listener should be shutting down. Touching this pipe caused the listener to abort it's loop and destroy.

A different solution is needed for Windows, which will be contributed in the near future.