### PR TITLE
Enable 'make test' target

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -58,6 +58,7 @@ endif()
 
 # Tests
 if (CLI_BuildTests)
+	enable_testing()
 	add_subdirectory(test)
 endif()
 


### PR DESCRIPTION
This PR enables `make test` if configured with `-DCLI_BuildTests=ON`, which makes it easier for package managers (and users) to run the tests.

I see that `enable_testing()` is enabled in `test/CMakeLists.txt`. But this does not work for me using CMake 3.14.3. The target seems valid, but is a no-op. Enabling in the root `CMakeLists.txt` seems to work.