### PR TITLE
Generate cli.pc configuration file for pkg-config

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -51,6 +51,7 @@ target_include_directories(cli
 target_link_libraries(cli INTERFACE Boost::system Threads::Threads)
 target_compile_features(cli INTERFACE cxx_std_14)
 
+
 # Examples
 if (CLI_BuildExamples)
     add_subdirectory(examples)
@@ -72,10 +73,26 @@ configure_package_config_file(
 	INSTALL_DESTINATION "lib/cmake/cli"
 )
 
+include(GNUInstallDirs)
+# Generate pkg-config .pc file
+set(PKGCONFIG_INSTALL_DIR
+	${CMAKE_INSTALL_DATAROOTDIR}/pkgconfig
+	CACHE PATH "Installation directory for pkg-config (cli.pc) file"
+)
+configure_file(
+	"cli.pc.in"
+	"cli.pc"
+	@ONLY
+)
+
 install(TARGETS cli EXPORT cliTargets DESTINATION lib)
 install(EXPORT cliTargets FILE cliTargets.cmake NAMESPACE cli:: DESTINATION lib/cmake/cli)
 
 install(
 	FILES "${CMAKE_CURRENT_BINARY_DIR}/cliConfig.cmake"
 	DESTINATION "lib/cmake/cli"
+)
+install(
+      FILES "${CMAKE_CURRENT_BINARY_DIR}/cli.pc"
+      DESTINATION ${PKGCONFIG_INSTALL_DIR}
 )

--- a/cli.pc.in
+++ b/cli.pc.in
@@ -1,0 +1,8 @@
+prefix=@CMAKE_INSTALL_PREFIX@
+includedir=${prefix}/include
+
+Name: cli
+Description: A cross-platform header only C++14 library for interactive command line interfaces (Cisco style)
+URL: https://github.com/daniele77/cli
+Version: @cli_VERSION@
+Cflags: -I${includedir}


### PR DESCRIPTION
This is a PR to make it easier for non-cmake projects to use cli by providing a pkg-config file. 

Since cli is architecture independent the generated `cli.pc` is installed in the data dir (`GNUInstallDirs` defined). The typical full path will be `$prefix/share/pkgconfig/cli.pc`.

If user installs into a prefix where `pkg-config` is not searching by default they have to provide the path via `PKG_CONFIG_PATH`.
```
> PREFIX=<some dir>
> cmake -DCMAKE_INSTALL_PREFIX=$PREFIX .. && make install
> tree $PREFIX
├── include
│   └── cli
│       ├── cliasyncsession.h
│       ├── ...
│       └── winkeyboard.h
├── lib
│   └── cmake
│       └── cli
│           ├── cliConfig.cmake
│           └── cliTargets.cmake
└── share
    └── pkgconfig
        └── cli.pc

# Verify that pkg-config works
> export PKG_CONFIG_PATH=$PREFIX/share/pkgconfig
> pkg-config cli --modversion
1.1
> pkg-config cli --cflags
-I<$PREFIX>/include
```
