### PR TITLE
Fix backspace key and not arrow keys

### DIFF
--- a/include/cli/remotecli.h
+++ b/include/cli/remotecli.h
@@ -465,7 +465,7 @@ protected:
             case Step::_1:
                 switch( c )
                 {
-                    case 127: Notify(std::make_pair(KeyType::backspace,' ')); break;
+                    case 8: case 127: Notify(std::make_pair(KeyType::backspace, ' ')); break; // Backspace or Delete
                     //case 10: Notify(std::make_pair(KeyType::ret,' ')); break;
                     case 27: step = Step::_2; break;  // symbol
                     case 13: step = Step::wait_0; break;  // wait for 0 (ENTER key)
@@ -494,13 +494,13 @@ protected:
             case Step::_3: // got 27 and 91
                 switch( c )
                 {
-                    case 51: step = Step::_4; break;  // not arrow keys
                     case 65: step = Step::_1; Notify(std::make_pair(KeyType::up,' ')); break;
                     case 66: step = Step::_1; Notify(std::make_pair(KeyType::down,' ')); break;
                     case 68: step = Step::_1; Notify(std::make_pair(KeyType::left,' ')); break;
                     case 67: step = Step::_1; Notify(std::make_pair(KeyType::right,' ')); break;
                     case 70: step = Step::_1; Notify(std::make_pair(KeyType::end,' ')); break;
                     case 72: step = Step::_1; Notify(std::make_pair(KeyType::home,' ')); break;
+                    default: step = Step::_4; break;  // not arrow keys
                 }
                 break;
 


### PR DESCRIPTION
Fixes #51 

Also fixes the "not arrow keys" inputs (try F1-9 keys for instance) where the state machine currently get stuck in state ` Step::_3`.

Tested with the Windows telnet client.