### PR TITLE
Remove consecutive duplicate commands on history

### DIFF
--- a/include/cli/history.h
+++ b/include/cli/history.h
@@ -54,13 +54,19 @@ public:
         if (mode == Mode::browsing)
         {
             assert(!buffer.empty());
-            buffer[current] = item;
+            if (buffer[1] == item)
+                buffer.pop_front();
+            else
+                buffer[current] = item;
         }
         else // Mode::inserting
         {
-            buffer.push_front(item);
-            if (buffer.size() > maxSize)
-                buffer.pop_back();
+            if (buffer.empty() || buffer[0] != item)
+            {
+                buffer.push_front(item);
+                if (buffer.size() > maxSize)
+                    buffer.pop_back();
+            }
         }
         mode = Mode::inserting;
     }

--- a/test/test_history.cpp
+++ b/test/test_history.cpp
@@ -71,7 +71,6 @@ BOOST_AUTO_TEST_CASE(Full)
     BOOST_CHECK_EQUAL(history.Next(), "");
 }
 
-
 BOOST_AUTO_TEST_CASE(Insertion)
 {
     History history(10);
@@ -87,6 +86,32 @@ BOOST_AUTO_TEST_CASE(Insertion)
     BOOST_CHECK_EQUAL(history.Next(), "item4");
     BOOST_CHECK_EQUAL(history.Previous("item4"), "foo");
     BOOST_CHECK_EQUAL(history.Previous("foo"), "item2");
+}
+
+BOOST_AUTO_TEST_CASE(InsertionIgnoreRepeat)
+{
+    History history(10);
+    history.NewCommand("item1");
+    history.NewCommand("item2");
+    history.NewCommand("item2");
+    history.NewCommand("item1");
+    history.NewCommand("item1");
+    history.NewCommand("item3");
+    history.NewCommand("item3");
+    history.NewCommand("item3");
+    history.NewCommand("item1");
+    history.NewCommand("item1");
+    history.NewCommand("item1");
+
+    BOOST_CHECK_EQUAL(history.Previous(""), "item1");
+    BOOST_CHECK_EQUAL(history.Previous("item1"), "item3");
+    BOOST_CHECK_EQUAL(history.Previous("item3"), "item1");
+    BOOST_CHECK_EQUAL(history.Previous("item1"), "item2");
+    BOOST_CHECK_EQUAL(history.Previous("item2"), "item1");
+    BOOST_CHECK_EQUAL(history.Next(), "item2");
+    BOOST_CHECK_EQUAL(history.Next(), "item1");
+    BOOST_CHECK_EQUAL(history.Next(), "item3");
+    BOOST_CHECK_EQUAL(history.Next(), "item1");
 }
 
 BOOST_AUTO_TEST_CASE(Empty)


### PR DESCRIPTION
As discussed on [Issue #55](https://github.com/daniele77/cli/issues/55), this PR replicates the bash history behavior: a command should not be stored in history if the previous is identical. I.e. the sequence of commands: A B B A A should result in the history content: A B A.
