### PR TITLE
Handle EOF / EOT / Ctrl-D situations in input on Linux.

### DIFF
--- a/include/cli/inputdevice.h
+++ b/include/cli/inputdevice.h
@@ -37,7 +37,7 @@
 namespace cli
 {
 
-enum class KeyType { ascii, up, down, left, right, backspace, canc, home, end, ret, ignored };
+enum class KeyType { ascii, up, down, left, right, backspace, canc, home, end, ret, ignored, eof };
 
 class InputDevice
 {

--- a/include/cli/inputhandler.h
+++ b/include/cli/inputhandler.h
@@ -83,6 +83,11 @@ private:
                 terminal.SetLine(session.PreviousCmd(line));
                 break;
             }
+            case Symbol::eof:
+            {
+                session.Exit();
+                break;
+            }
             case Symbol::tab:
             {
                 auto line = terminal.GetLine();

--- a/include/cli/linuxkeyboard.h
+++ b/include/cli/linuxkeyboard.h
@@ -80,6 +80,9 @@ private:
         int ch = getchar();
         switch( ch )
         {
+            case EOF:
+            case 4:  // EOT
+                return std::make_pair(KeyType::eof,' '); break;
             case 127: return std::make_pair(KeyType::backspace,' '); break;
             case 10: return std::make_pair(KeyType::ret,' '); break;
             case 27: // symbol

--- a/include/cli/remotecli.h
+++ b/include/cli/remotecli.h
@@ -465,6 +465,9 @@ protected:
             case Step::_1:
                 switch( c )
                 {
+                    case EOF:
+                    case 4:  // EOT
+                        Notify(std::make_pair(KeyType::eof,' ')); break;
                     case 127: Notify(std::make_pair(KeyType::backspace,' ')); break;
                     //case 10: Notify(std::make_pair(KeyType::ret,' ')); break;
                     case 27: step = Step::_2; break;  // symbol

--- a/include/cli/terminal.h
+++ b/include/cli/terminal.h
@@ -43,7 +43,8 @@ enum class Symbol
     command,
     up,
     down,
-    tab
+    tab,
+    eof
 };
 
 class Terminal
@@ -98,6 +99,9 @@ class Terminal
             }
             case KeyType::up:
                 return std::make_pair(Symbol::up, std::string{});
+                break;
+            case KeyType::eof:
+                return std::make_pair(Symbol::eof, std::string{});
                 break;
             case KeyType::down:
                 return std::make_pair(Symbol::down, std::string{});


### PR DESCRIPTION
This exits the session when EOF is sent on that session's input.

I tested this locally and it appears to work as expected.

Edit: I only tested it on Linux since that's what I have. I have not modified winkeyboard anyway.