### PR TITLE
Remove unnecessary detail namespace prefixes

### DIFF
--- a/include/cli/detail/keyboard.h
+++ b/include/cli/detail/keyboard.h
@@ -42,10 +42,10 @@
 
 #if defined(OS_LINUX) || defined(OS_MAC)
     #include "linuxkeyboard.h"
-    namespace cli { namespace detail { using Keyboard = detail::LinuxKeyboard; } }
+    namespace cli { namespace detail { using Keyboard = LinuxKeyboard; } }
 #elif defined(OS_WIN)
     #include "winkeyboard.h"
-    namespace cli { namespace detail { using Keyboard = detail::WinKeyboard; } }
+    namespace cli { namespace detail { using Keyboard = WinKeyboard; } }
 #else
     #error "Platform not supported (yet)."
 #endif


### PR DESCRIPTION
Removed not needed detail namespace prefixes on keyboard.h file, since the expression is already inside a "namespace detail" block. I guess it was duplicated while adding the detail namespace on different classes. The examples and tests build and run well for me, but when I try to build cli library as part of my main project, I get an error as follows:

`/usr/local/include/cli/detail/keyboard.h:45:65: error: ‘LinuxKeyboard’ in namespace ‘cli::detail::detail’ does not name a type
     namespace cli { namespace detail { using Keyboard = detail::LinuxKeyboard; } }`

I guess it depends on how the compiler and/or build system is configured. But I think removing the prefix is better since it is redundant anyway.
