### PR TITLE
Replaced Boost.Asio with Asio (much smaller library)

### DIFF
--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -13,6 +13,7 @@ jobs:
       run: |
         sudo apt-get -y update
         sudo apt-get -y install libboost-all-dev
+        sudo apt-get -y install libasio-dev
     - name: run cmake
       run: |
         mkdir build

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,7 +31,7 @@ cmake_minimum_required(VERSION 3.8)
 
 project(cli VERSION 1.2.1 LANGUAGES CXX)
 
-option(CLI_BuildExamples "Build the examples." ON)
+option(CLI_BuildExamples "Build the examples." OFF)
 option(CLI_BuildTests "Build the unit tests." OFF)
 
 set(Boost_NO_BOOST_CMAKE ON)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,11 +31,12 @@ cmake_minimum_required(VERSION 3.8)
 
 project(cli VERSION 1.2.1 LANGUAGES CXX)
 
-option(CLI_BuildExamples "Build the examples." OFF)
+option(CLI_BuildExamples "Build the examples." ON)
 option(CLI_BuildTests "Build the unit tests." OFF)
 
 set(Boost_NO_BOOST_CMAKE ON)
-find_package(Boost 1.55 REQUIRED COMPONENTS system)
+#find_package(Boost 1.55 REQUIRED COMPONENTS system)
+find_package(asio CONFIG REQUIRED)
 find_package(Threads REQUIRED)
 
 # Add Library
@@ -49,7 +50,8 @@ target_include_directories(cli
         $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
 )
 
-target_link_libraries(cli INTERFACE Boost::system Threads::Threads)
+#target_link_libraries(cli INTERFACE Boost::system Threads::Threads)
+target_link_libraries(cli INTERFACE asio asio::asio Threads::Threads)
 target_compile_features(cli INTERFACE cxx_std_14)
 target_compile_definitions(cli INTERFACE BOOST_ASIO_NO_DEPRECATED=1)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,7 +35,7 @@ option(CLI_BuildExamples "Build the examples." OFF)
 option(CLI_BuildTests "Build the unit tests." OFF)
 
 set(Boost_NO_BOOST_CMAKE ON)
-#find_package(Boost 1.55 REQUIRED COMPONENTS system)
+find_package(Boost 1.55 REQUIRED COMPONENTS system)
 find_package(asio CONFIG REQUIRED)
 find_package(Threads REQUIRED)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,8 +34,10 @@ project(cli VERSION 1.2.1 LANGUAGES CXX)
 option(CLI_BuildExamples "Build the examples." OFF)
 option(CLI_BuildTests "Build the unit tests." OFF)
 
-set(Boost_NO_BOOST_CMAKE ON)
-find_package(Boost 1.55 REQUIRED COMPONENTS system)
+if(CLI_BuildTests)
+	set(Boost_NO_BOOST_CMAKE ON)
+	find_package(Boost 1.55 REQUIRED COMPONENTS system)
+endif()
 find_package(asio CONFIG REQUIRED)
 find_package(Threads REQUIRED)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,7 +38,9 @@ if(CLI_BuildTests)
 	set(Boost_NO_BOOST_CMAKE ON)
 	find_package(Boost 1.55 REQUIRED COMPONENTS system)
 endif()
-find_package(asio CONFIG REQUIRED)
+find_path(ASIO_INCLUDE_DIR asio.hpp)
+message("asio include dir: ${ASIO_INCLUDE_DIR}")
+#find_package(asio CONFIG REQUIRED)
 find_package(Threads REQUIRED)
 
 # Add Library
@@ -52,7 +54,8 @@ target_include_directories(cli
         $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
 )
 
-target_link_libraries(cli INTERFACE asio asio::asio Threads::Threads)
+target_link_libraries(cli INTERFACE Threads::Threads)
+target_include_directories(cli INTERFACE ${ASIO_INCLUDE_DIR})
 target_compile_features(cli INTERFACE cxx_std_14)
 target_compile_definitions(cli INTERFACE BOOST_ASIO_NO_DEPRECATED=1)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -52,7 +52,6 @@ target_include_directories(cli
         $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
 )
 
-#target_link_libraries(cli INTERFACE Boost::system Threads::Threads)
 target_link_libraries(cli INTERFACE asio asio::asio Threads::Threads)
 target_compile_features(cli INTERFACE cxx_std_14)
 target_compile_definitions(cli INTERFACE BOOST_ASIO_NO_DEPRECATED=1)

--- a/examples/asyncsession.cpp
+++ b/examples/asyncsession.cpp
@@ -85,9 +85,9 @@ int main()
     cli.ExitAction( [](auto& out){ out << "Goodbye and thanks for all the fish.\n"; } );
 
 #if BOOST_VERSION < 106600
-    boost::asio::io_service ios;
+    asio::io_service ios;
 #else
-    boost::asio::io_context ios;
+    asio::io_context ios;
 #endif
     CliAsyncSession session(ios, cli);
     session.ExitAction(

--- a/examples/complete.cpp
+++ b/examples/complete.cpp
@@ -43,9 +43,9 @@ using namespace std;
 int main()
 {
 #if BOOST_VERSION < 106600
-    boost::asio::io_service ios;
+    asio::io_service ios;
 #else
-    boost::asio::io_context ios;
+    asio::io_context ios;
 #endif
     CmdHandler colorCmd;
     CmdHandler nocolorCmd;
@@ -204,9 +204,9 @@ int main()
 #else // ENABLE_TELNET_SERVER
 
 #if BOOST_VERSION < 106600
-    boost::asio::io_service::work work(ios);
+    asio::io_service::work work(ios);
 #else
-        auto work = boost::asio::make_work_guard(ios);
+        auto work = asio::make_work_guard(ios);
 #endif  
 
 #endif // ENABLE_TELNET_SERVER

--- a/examples/pluginmanager.cpp
+++ b/examples/pluginmanager.cpp
@@ -228,9 +228,9 @@ private:
 int main()
 {
 #if BOOST_VERSION < 106600
-    boost::asio::io_service ioc;
+    asio::io_service ioc;
 #else
-    boost::asio::io_context ioc;
+    asio::io_context ioc;
 #endif
     CmdHandler colorCmd;
     CmdHandler nocolorCmd;    
@@ -300,9 +300,9 @@ int main()
     );
 
 #if BOOST_VERSION < 106600
-    boost::asio::io_service::work work(ioc);
+    asio::io_service::work work(ioc);
 #else
-    auto work = boost::asio::make_work_guard(ioc);
+    auto work = asio::make_work_guard(ioc);
 #endif    
     ioc.run();
 

--- a/include/cli/cliasyncsession.h
+++ b/include/cli/cliasyncsession.h
@@ -44,7 +44,7 @@ namespace cli
 class CliAsyncSession : public CliSession
 {
 public:
-    CliAsyncSession(detail::asio::BoostExecutor::ContextType& ios, Cli& _cli) :
+    CliAsyncSession(detail::notboost::BoostExecutor::ContextType& ios, Cli& _cli) :
         CliSession(_cli, std::cout, 1),
         input(ios, ::dup( STDIN_FILENO))
     {
@@ -61,7 +61,7 @@ private:
     {
         Prompt();
         // Read a line of input entered by the user.
-        boost::asio::async_read_until(
+        asio::async_read_until(
             input,
             inputBuffer,
             '\n',
@@ -73,12 +73,12 @@ private:
 
     void NewLine( const boost::system::error_code& error, std::size_t length )
     {
-        if ( !error || error == boost::asio::error::not_found )
+        if ( !error || error == asio::error::not_found )
         {
             auto bufs = inputBuffer.data();
             auto size = static_cast<long>(length);
             if ( !error ) --size; // remove \n
-            std::string s( boost::asio::buffers_begin( bufs ), boost::asio::buffers_begin( bufs ) + size );
+            std::string s( asio::buffers_begin( bufs ), asio::buffers_begin( bufs ) + size );
             inputBuffer.consume( length );
 
             Feed( s );
@@ -90,8 +90,8 @@ private:
         }
     }
 
-    boost::asio::streambuf inputBuffer;
-    boost::asio::posix::stream_descriptor input;
+    asio::streambuf inputBuffer;
+    asio::posix::stream_descriptor input;
 };
 
 } // namespace

--- a/include/cli/cliasyncsession.h
+++ b/include/cli/cliasyncsession.h
@@ -34,7 +34,7 @@
 #include "detail/boostasio.h"
 #include "cli.h" // CliSession
 
-#if !defined(BOOST_ASIO_HAS_POSIX_STREAM_DESCRIPTOR)
+#if !defined(BOOST_ASIO_HAS_POSIX_STREAM_DESCRIPTOR) && !defined(USE_ASIO_INSTEAD)
 #    error Async session is not supported on this platform.
 #endif
 

--- a/include/cli/cliasyncsession.h
+++ b/include/cli/cliasyncsession.h
@@ -71,7 +71,7 @@ private:
         );
     }
 
-    void NewLine( const boost::system::error_code& error, std::size_t length )
+    void NewLine( const std::error_code& error, std::size_t length )
     {
         if ( !error || error == asio::error::not_found )
         {

--- a/include/cli/clilocalsession.h
+++ b/include/cli/clilocalsession.h
@@ -42,9 +42,9 @@ class CliLocalTerminalSession : public CliSession
 {
 public:
 
-    CliLocalTerminalSession(Cli& _cli, detail::asio::BoostExecutor::ContextType& ios, std::ostream& _out, std::size_t historySize = 100) :
+    CliLocalTerminalSession(Cli& _cli, detail::notboost::BoostExecutor::ContextType& ios, std::ostream& _out, std::size_t historySize = 100) :
         CliSession(_cli, _out, historySize),
-        kb(detail::asio::BoostExecutor(ios)),
+        kb(detail::notboost::BoostExecutor(ios)),
         ih(*this, kb)
     {
         Prompt();

--- a/include/cli/detail/NOTboostasio.h
+++ b/include/cli/detail/NOTboostasio.h
@@ -27,36 +27,40 @@
  * DEALINGS IN THE SOFTWARE.
  ******************************************************************************/
 
-#ifndef CLI_DETAIL_OLDBOOSTASIO_H_
-#define CLI_DETAIL_OLDBOOSTASIO_H_
+#ifndef CLI_DETAIL_NEWBOOSTASIO_H_
+#define CLI_DETAIL_NEWBOOSTASIO_H_
 
-#include <boost/asio.hpp>
+#if BOOST_VERSION >= 107400
+#   define BOOST_ASIO_USE_TS_EXECUTOR_AS_DEFAULT
+#endif
+
+#include "asio.hpp"
 
 namespace cli {
 namespace detail {
-namespace oldboost {
+namespace notboost {
 
 class BoostExecutor
 {
 public:
-    using ContextType = asio::io_service;
-    explicit BoostExecutor(ContextType& _ios) :
-        ios(_ios) {}
+    using ContextType = asio::io_context;
+    explicit BoostExecutor(ContextType& ios) :
+        executor(ios.get_executor()) {}
     explicit BoostExecutor(asio::ip::tcp::socket& socket) :
-        ios(socket.get_io_service()) {}
-    template <typename T> void Post(T&& t) { ios.post(std::forward<T>(t)); }
+        executor(socket.get_executor()) {}
+    template <typename T> void Post(T&& t) { asio::post(executor, std::forward<T>(t)); }
 private:
-    ContextType& ios;
+    asio::executor executor;
 };
 
 inline asio::ip::address IpAddressFromString(const std::string& address)
 {
-    return asio::ip::address::from_string(address);
+    return asio::ip::make_address(address);
 }
 
-} // namespace oldboost
+} // namespace newboost
 } // namespace detail
 } // namespace cli
 
-#endif // CLI_DETAIL_OLDBOOSTASIO_H_
+#endif // CLI_DETAIL_NEWBOOSTASIO_H_
 

--- a/include/cli/detail/boostasio.h
+++ b/include/cli/detail/boostasio.h
@@ -33,7 +33,7 @@
 #define USE_ASIO_INSTEAD
 #ifdef USE_ASIO_INSTEAD
 
-#include "notboostasio.h"
+#include "NOTboostasio.h"
 
 namespace cli {
     namespace detail {

--- a/include/cli/detail/boostasio.h
+++ b/include/cli/detail/boostasio.h
@@ -30,22 +30,36 @@
 #ifndef CLI_DETAIL_BOOSTIO_H_
 #define CLI_DETAIL_BOOSTIO_H_
 
+#define USE_ASIO_INSTEAD
+#ifdef USE_ASIO_INSTEAD
+
+#include "notboostasio.h"
+
+namespace cli {
+    namespace detail {
+        //namespace asio = notboost;
+    }
+}
+
+#else
 #include <boost/version.hpp>
 
 #if BOOST_VERSION < 106600
-    #include "oldboostasio.h"
-    namespace cli {
+#include "oldboostasio.h"
+namespace cli {
     namespace detail {
         namespace asio = oldboost;
     }
-    }
+}
 #else
-    #include "newboostasio.h"
-    namespace cli {
+#include "newboostasio.h"
+namespace cli {
     namespace detail {
         namespace asio = newboost;
     }
-    }
+}
 #endif
+
+#endif // USE_ASIO_INSTEAD
 
 #endif // CLI_DETAIL_BOOSTIO_H_

--- a/include/cli/detail/inputdevice.h
+++ b/include/cli/detail/inputdevice.h
@@ -46,7 +46,7 @@ class InputDevice
 public:
     using Handler = std::function< void( std::pair<KeyType,char> ) >;
 
-    InputDevice(asio::BoostExecutor ex) : executor(ex) {}
+    InputDevice(notboost::BoostExecutor ex) : executor(ex) {}
     virtual ~InputDevice() = default;
 
     template <typename H>
@@ -61,7 +61,7 @@ protected:
 
 private:
 
-    asio::BoostExecutor executor;
+    notboost::BoostExecutor executor;
     Handler handler;
 };
 

--- a/include/cli/detail/newboostasio.h
+++ b/include/cli/detail/newboostasio.h
@@ -43,19 +43,19 @@ namespace newboost {
 class BoostExecutor
 {
 public:
-    using ContextType = boost::asio::io_context;
+    using ContextType = asio::io_context;
     explicit BoostExecutor(ContextType& ios) :
         executor(ios.get_executor()) {}
-    explicit BoostExecutor(boost::asio::ip::tcp::socket& socket) :
+    explicit BoostExecutor(asio::ip::tcp::socket& socket) :
         executor(socket.get_executor()) {}
-    template <typename T> void Post(T&& t) { boost::asio::post(executor, std::forward<T>(t)); }
+    template <typename T> void Post(T&& t) { asio::post(executor, std::forward<T>(t)); }
 private:
-    boost::asio::executor executor;
+    asio::executor executor;
 };
 
-inline boost::asio::ip::address IpAddressFromString(const std::string& address)
+inline asio::ip::address IpAddressFromString(const std::string& address)
 {
-    return boost::asio::ip::make_address(address);
+    return asio::ip::make_address(address);
 }
 
 } // namespace newboost

--- a/include/cli/detail/newboostasio.h
+++ b/include/cli/detail/newboostasio.h
@@ -43,19 +43,19 @@ namespace newboost {
 class BoostExecutor
 {
 public:
-    using ContextType = asio::io_context;
+    using ContextType = boost::asio::io_context;
     explicit BoostExecutor(ContextType& ios) :
         executor(ios.get_executor()) {}
-    explicit BoostExecutor(asio::ip::tcp::socket& socket) :
+    explicit BoostExecutor(boost::asio::ip::tcp::socket& socket) :
         executor(socket.get_executor()) {}
-    template <typename T> void Post(T&& t) { asio::post(executor, std::forward<T>(t)); }
+    template <typename T> void Post(T&& t) { boost::asio::post(executor, std::forward<T>(t)); }
 private:
-    asio::executor executor;
+    boost::asio::executor executor;
 };
 
-inline asio::ip::address IpAddressFromString(const std::string& address)
+inline boost::asio::ip::address IpAddressFromString(const std::string& address)
 {
-    return asio::ip::make_address(address);
+    return boost::asio::ip::make_address(address);
 }
 
 } // namespace newboost
@@ -63,4 +63,3 @@ inline asio::ip::address IpAddressFromString(const std::string& address)
 } // namespace cli
 
 #endif // CLI_DETAIL_NEWBOOSTASIO_H_
-

--- a/include/cli/detail/oldboostasio.h
+++ b/include/cli/detail/oldboostasio.h
@@ -39,19 +39,19 @@ namespace oldboost {
 class BoostExecutor
 {
 public:
-    using ContextType = asio::io_service;
+    using ContextType = boost::asio::io_service;
     explicit BoostExecutor(ContextType& _ios) :
         ios(_ios) {}
-    explicit BoostExecutor(asio::ip::tcp::socket& socket) :
+    explicit BoostExecutor(boost::asio::ip::tcp::socket& socket) :
         ios(socket.get_io_service()) {}
     template <typename T> void Post(T&& t) { ios.post(std::forward<T>(t)); }
 private:
     ContextType& ios;
 };
 
-inline asio::ip::address IpAddressFromString(const std::string& address)
+inline boost::asio::ip::address IpAddressFromString(const std::string& address)
 {
-    return asio::ip::address::from_string(address);
+    return boost::asio::ip::address::from_string(address);
 }
 
 } // namespace oldboost
@@ -59,4 +59,3 @@ inline asio::ip::address IpAddressFromString(const std::string& address)
 } // namespace cli
 
 #endif // CLI_DETAIL_OLDBOOSTASIO_H_
-

--- a/include/cli/detail/server.h
+++ b/include/cli/detail/server.h
@@ -32,7 +32,7 @@
 
 #include <memory>
 #include <queue>
-#include "boostasio.h"
+#include "asio.hpp"
 
 namespace cli
 {
@@ -51,21 +51,21 @@ public:
 
 protected:
 
-    Session(boost::asio::ip::tcp::socket _socket) : socket(std::move(_socket)), outStream( this ) {}
+    Session(asio::ip::tcp::socket _socket) : socket(std::move(_socket)), outStream( this ) {}
 
     virtual void Disconnect()
     {
-        socket.shutdown( boost::asio::ip::tcp::socket::shutdown_both );
+        socket.shutdown( asio::ip::tcp::socket::shutdown_both );
         socket.close();
     }
 
     virtual void Read()
     {
       auto self( shared_from_this() );
-      socket.async_read_some( boost::asio::buffer( data, max_length ),
-          [ this, self ]( boost::system::error_code ec, std::size_t length )
+      socket.async_read_some( asio::buffer( data, max_length ),
+          [ this, self ]( std::error_code ec, std::size_t length )
           {
-              if ( !socket.is_open() || ( ec == boost::asio::error::eof ) || ( ec == boost::asio::error::connection_reset ) )
+              if ( !socket.is_open() || ( ec == asio::error::eof ) || ( ec == asio::error::connection_reset ) )
                   OnDisconnect();
               else if ( ec )
                   OnError();
@@ -79,9 +79,9 @@ protected:
 
     virtual void Send(const std::string& msg)
     {
-        boost::system::error_code ec;
-        boost::asio::write(socket, boost::asio::buffer(msg), ec);
-        if ((ec == boost::asio::error::eof) || (ec == boost::asio::error::connection_reset))
+        std::error_code ec;
+        asio::write(socket, asio::buffer(msg), ec);
+        if ((ec == asio::error::eof) || (ec == asio::error::connection_reset))
             OnDisconnect();
         else if (ec)
             OnError();
@@ -110,7 +110,7 @@ private:
         return c;
     }
 
-    boost::asio::ip::tcp::socket socket;
+    asio::ip::tcp::socket socket;
     enum { max_length = 1024 };
     char data[ max_length ];
     std::ostream outStream;
@@ -124,32 +124,32 @@ public:
     Server( const Server& ) = delete;
     Server& operator = ( const Server& ) = delete;
 
-    Server(asio::BoostExecutor::ContextType& ios, unsigned short port) :
-        acceptor( ios, boost::asio::ip::tcp::endpoint( boost::asio::ip::tcp::v4(), port )),
+    Server(notboost::BoostExecutor::ContextType& ios, unsigned short port) :
+        acceptor( ios, asio::ip::tcp::endpoint( asio::ip::tcp::v4(), port )),
         socket( ios )
     {
         Accept();
     }
-    Server(asio::BoostExecutor::ContextType& ios, std::string address, unsigned short port) :
-        acceptor( ios, boost::asio::ip::tcp::endpoint(asio::IpAddressFromString(address), port)),
+    Server(notboost::BoostExecutor::ContextType& ios, std::string address, unsigned short port) :
+        acceptor( ios, asio::ip::tcp::endpoint(asio::ip::address::from_string(address), port)),
         socket( ios )
     {
         Accept();
     }
     virtual ~Server() = default;
     // returns shared_ptr instead of unique_ptr because Session needs to use enable_shared_from_this
-    virtual std::shared_ptr< Session > CreateSession( boost::asio::ip::tcp::socket socket ) = 0;
+    virtual std::shared_ptr< Session > CreateSession( asio::ip::tcp::socket socket ) = 0;
 private:
     void Accept()
     {
-        acceptor.async_accept( socket, [this](boost::system::error_code ec)
+        acceptor.async_accept( socket, [this](std::error_code ec)
             {
                 if ( !ec ) CreateSession( std::move( socket ) ) -> Start();
                 Accept();
             });
     }
-    boost::asio::ip::tcp::acceptor acceptor;
-    boost::asio::ip::tcp::socket socket;
+    asio::ip::tcp::acceptor acceptor;
+    asio::ip::tcp::socket socket;
 };
 
 } // namespace detail

--- a/include/cli/detail/winkeyboard.h
+++ b/include/cli/detail/winkeyboard.h
@@ -49,7 +49,7 @@ namespace detail
 class WinKeyboard : public InputDevice
 {
 public:
-    explicit WinKeyboard(asio::BoostExecutor ex) :
+    explicit WinKeyboard(notboost::BoostExecutor ex) :
         InputDevice(ex)
     {
         servant = std::make_unique<std::thread>([this]() { Read(); });

--- a/include/cli/remotecli.h
+++ b/include/cli/remotecli.h
@@ -45,7 +45,7 @@ namespace cli
 class TelnetSession : public detail::Session
 {
 public:
-    TelnetSession(boost::asio::ip::tcp::socket _socket) :
+    TelnetSession(asio::ip::tcp::socket _socket) :
         detail::Session(std::move(_socket))
     {}
 
@@ -427,10 +427,10 @@ private:
 class TelnetServer : public detail::Server
 {
 public:
-    TelnetServer(detail::asio::BoostExecutor::ContextType& ios, unsigned short port) :
+    TelnetServer(detail::notboost::BoostExecutor::ContextType& ios, unsigned short port) :
         detail::Server(ios, port)
     {}
-    virtual std::shared_ptr<detail::Session> CreateSession(boost::asio::ip::tcp::socket _socket) override
+    virtual std::shared_ptr<detail::Session> CreateSession(asio::ip::tcp::socket _socket) override
     {
         return std::make_shared<TelnetSession>(std::move(_socket));
     }
@@ -442,8 +442,8 @@ class CliTelnetSession : public detail::InputDevice, public TelnetSession, publi
 {
 public:
 
-    CliTelnetSession(boost::asio::ip::tcp::socket _socket, Cli& _cli, std::function< void(std::ostream&)> _exitAction, std::size_t historySize ) :
-        InputDevice(detail::asio::BoostExecutor(_socket)),
+    CliTelnetSession(asio::ip::tcp::socket _socket, Cli& _cli, std::function< void(std::ostream&)> _exitAction, std::size_t historySize ) :
+        InputDevice(detail::notboost::BoostExecutor(_socket)),
         TelnetSession(std::move(_socket)),
         CliSession(_cli, TelnetSession::OutStream(), historySize),
         poll(*this, *this)
@@ -540,12 +540,12 @@ private:
 class CliTelnetServer : public detail::Server
 {
 public:
-    CliTelnetServer(detail::asio::BoostExecutor::ContextType& ios, unsigned short port, Cli& _cli, std::size_t _historySize=100 ) :
+    CliTelnetServer(detail::notboost::BoostExecutor::ContextType& ios, unsigned short port, Cli& _cli, std::size_t _historySize=100 ) :
         detail::Server(ios, port),
         cli(_cli),
         historySize(_historySize)
     {}
-    CliTelnetServer(detail::asio::BoostExecutor::ContextType& ios, std::string address, unsigned short port, Cli& _cli, std::size_t _historySize=100 ) :
+    CliTelnetServer(detail::notboost::BoostExecutor::ContextType& ios, std::string address, unsigned short port, Cli& _cli, std::size_t _historySize=100 ) :
         detail::Server(ios, address, port),
         cli(_cli),
         historySize(_historySize)
@@ -554,7 +554,7 @@ public:
     {
         exitAction = action;
     }
-    virtual std::shared_ptr<detail::Session> CreateSession(boost::asio::ip::tcp::socket _socket) override
+    virtual std::shared_ptr<detail::Session> CreateSession(asio::ip::tcp::socket _socket) override
     {
         return std::make_shared<CliTelnetSession>(std::move(_socket), cli, exitAction, historySize);
     }

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -32,10 +32,10 @@ project(cli_test)
 enable_testing()
 
 # replace XX with the version you have
-set(Boost_ADDITIONAL_VERSIONS "1.66" "1.66.0")
+set(Boost_ADDITIONAL_VERSIONS "1.66" "1.66.0" "1.73.0")
 
 # finds boost, triggers an error otherwise
-find_package(Boost 1.55 REQUIRED COMPONENTS unit_test_framework)
+find_package(Boost REQUIRED COMPONENTS unit_test_framework)
 
 # creates the executable
 add_executable(

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -32,10 +32,10 @@ project(cli_test)
 enable_testing()
 
 # replace XX with the version you have
-set(Boost_ADDITIONAL_VERSIONS "1.66" "1.66.0" "1.73.0")
+set(Boost_ADDITIONAL_VERSIONS "1.66" "1.66.0")
 
 # finds boost, triggers an error otherwise
-find_package(Boost REQUIRED COMPONENTS unit_test_framework)
+find_package(Boost 1.55 REQUIRED COMPONENTS unit_test_framework)
 
 # creates the executable
 add_executable(


### PR DESCRIPTION
This was much easier than I expected. I basically just messed with the namespaces to rearrange things to depend on Asio instead of Boost. I had to change boost::system::error_code to std::error_code in a few places, but that's consistent with the other differences of Boost-less Asio. More info on that: https://think-async.com/Asio/AsioAndBoostAsio.html

I wasn't able to get tests working immediately because I had some issues with my local Boost library. I did try the Windows examples, though, and they all worked!