### PR TITLE
fix for gcc 11

### DIFF
--- a/include/cli/detail/fromstring.h
+++ b/include/cli/detail/fromstring.h
@@ -54,6 +54,7 @@ T from_string(const std::string& s)
 #else
 
 #include <exception>
+#include <limits>
 #include <string>
 #include <sstream>
 

--- a/include/cli/detail/history.h
+++ b/include/cli/detail/history.h
@@ -31,6 +31,7 @@
 #define CLI_DETAIL_HISTORY_H_
 
 #include <deque>
+#include <limits>
 #include <vector>
 #include <string>
 #include <algorithm>


### PR DESCRIPTION
With GCC 11.1.0 I had some compilation bugs due to a missing header. This patch fixes those problems.