### PR TITLE
Add starting conanfile.py for conan packaging

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -1,0 +1,49 @@
+from conans import ConanFile, CMake, tools
+
+class Cli(ConanFile):
+    name = "cli"
+    version = "v1.2.1"
+    license = "BSL-1.0"
+    url = "https://github.com/daniele77/cli"
+    settings = "os", "compiler", "arch", "build_type"
+    options = {"use_boost": [True, False]}
+    default_options = {"use_boost": True}
+    generators = "cmake"
+
+    def package_id(self):
+        if not self.options.use_boost:
+            self.info.header_only()
+
+    def source(self):
+        tools.get("https://github.com/daniele77/cli/archive/refs/tags/v1.2.1.tar.gz")
+        tools.replace_in_file("cli-1.2.1/CMakeLists.txt", "project(cli VERSION 1.2.1 LANGUAGES CXX)",
+                              '''project(cli VERSION 1.2.1 LANGUAGES CXX)
+include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
+conan_basic_setup()''')
+
+    def requirements(self):
+        if self.options.use_boost:
+            self.requires("boost/[>1.55.0]")
+
+    def build(self):
+        if self.options.use_boost:
+            cmake = CMake(self)
+            cmake.definitions["CLI_UseBoostAsio"] = "ON"
+            # make sure to link against static in this case
+            if not self.options["boost"].shared:
+                tools.replace_in_file("cli-1.2.1/test/CMakeLists.txt", 'target_compile_definitions(test_suite PRIVATE "BOOST_TEST_DYN_LINK=1")',
+                                    '#target_compile_definitions(test_suite PRIVATE "BOOST_TEST_DYN_LINK=1")')
+            cmake.definitions["CLI_BuildExamples"] = "ON"
+            if tools.get_env("CONAN_RUN_TESTS",True):
+                cmake.definitions["CLI_BuildTests"] = "ON"
+            cmake.configure(source_folder="cli-1.2.1")
+            cmake.build()
+            if tools.get_env("CONAN_RUN_TESTS",True):
+                cmake.test()
+
+    def package(self):
+        self.copy("*.h", src="cli-1.2.1")
+        self.copy("*", dst="bin", src="bin", keep_path=False)
+
+    def deploy(self):
+        self.copy("*", dst="bin", src="bin")


### PR DESCRIPTION
As mentioned in #113 I believe it would be useful to add conan support.  I've added a conanfile.py recipe file in this commit.   For the moment it is tied specifically to the 1.2.1 release and pulls the files from the tar.gz based on the tag.

In order to use it in a conan enabled environment (like the docker image conanio/gcc10) run the command: `conan create cli @/` to create a conan package which can be uploaded.  Some notes about what is here:
- The default usage attempts to build the examples and run the tests.
- When the examples are built they are included in the package so while a header only library usually has one version this could have multiple.  When the examples are not include it does go to a header only package id.
- There is an option for whether or not you want to use boost.  Currently this controls only if the examples are included the package because it seems the current examples build does not handle not having boost to only build the items that do not depend on it. Using the conan create command you can include changing the option like this: `-o use_boost=False`
- The conan package changes how Boost unit tests are used in the case where Boost has only static libraries.

I've tested this on the docker image noted above as well as a cross compile in docker image conanio/gcc6-armv7hf.   When cross compiling the CONAN_RUN_TESTS env should be set since tests can run.

Please let me know what you think.
