### PR TITLE
Embed workguard in ASIOLIB

### DIFF
--- a/include/cli/detail/newboostasiolib.h
+++ b/include/cli/detail/newboostasiolib.h
@@ -46,7 +46,6 @@ class NewBoostAsioLib
 public:
 
     using ContextType = boost::asio::io_context;
-    using WorkGuard = boost::asio::executor_work_guard<boost::asio::io_context::executor_type>;
 
     class Executor
     {
@@ -64,6 +63,27 @@ public:
 #endif
          AsioExecutor executor;
     };
+
+	class WorkGuard
+	{
+	public:
+		explicit WorkGuard(ContextType& ios) :
+#if BOOST_VERSION >= 106600
+			workguard(boost::asio::make_work_guard(ios)) {}
+		void Reset() { workguard.reset(); }
+	private:
+		using AsioWorkGuard = boost::asio::executor_work_guard<boost::asio::io_context::executor_type>;
+#else
+			workguard(ios) {}
+		void Reset() {}
+	private:
+		using AsioWorkGuard = boost::asio::work;
+#endif
+
+	private:
+
+		AsioWorkGuard workguard;
+	};
 
     static boost::asio::ip::address IpAddressFromString(const std::string& address)
     {

--- a/include/cli/detail/newstandaloneasiolib.h
+++ b/include/cli/detail/newstandaloneasiolib.h
@@ -46,7 +46,6 @@ class NewStandaloneAsioLib
 public:
 
     using ContextType = asio::io_context;
-    using WorkGuard = asio::executor_work_guard<asio::io_context::executor_type>;
 
     class Executor
     {
@@ -64,6 +63,27 @@ public:
 #endif
          AsioExecutor executor;
     };
+
+	class WorkGuard
+	{
+	public:
+		explicit WorkGuard(ContextType& ios) :
+#if ASIO_VERSION >= 101300
+			workguard(asio::make_work_guard(ios)) {}
+		void Reset() { workguard.reset(); }
+	private:
+		using AsioWorkGuard = asio::executor_work_guard<asio::io_context::executor_type>;
+#else
+			workguard(ios) {}
+		void Reset() {}
+	private:
+		using AsioWorkGuard = asio::work;
+#endif
+
+	private:
+
+		AsioWorkGuard workguard;
+	};
 
     static asio::ip::address IpAddressFromString(const std::string& address)
     {

--- a/include/cli/detail/oldboostasiolib.h
+++ b/include/cli/detail/oldboostasiolib.h
@@ -44,7 +44,6 @@ class OldBoostAsioLib
 {
 public:
     using ContextType = boost::asio::io_service;
-    using WorkGuard = boost::asio::io_service::work;
 
     class Executor
     {
@@ -57,6 +56,16 @@ public:
     private:
         ContextType& ios;
     };
+
+	class WorkGuard
+	{
+	public:
+		explicit WorkGuard(ContextType& _ios) :
+			workguard(_ios) {}
+		void Reset() {}
+	private:
+		boost::asio::io_service::work workguard;
+	};
 
     static boost::asio::ip::address IpAddressFromString(const std::string& address)
     {

--- a/include/cli/detail/oldstandaloneasiolib.h
+++ b/include/cli/detail/oldstandaloneasiolib.h
@@ -47,7 +47,6 @@ class OldStandaloneAsioLib
 public:
 
     using ContextType = asio::io_service;
-    using WorkGuard = asio::io_service::work;
 
     class Executor
     {
@@ -60,6 +59,16 @@ public:
     private:
         ContextType& ios;
     };
+
+	class WorkGuard
+	{
+	public:
+		explicit WorkGuard(ContextType& _ios) :
+			workguard(_ios) {}
+		void Reset() {}
+	private:
+		asio::io_service::work workguard;
+	};
 
     static asio::ip::address IpAddressFromString(const std::string& address)
     {


### PR DESCRIPTION
See issue #127 

This is just a suggestion change, basically, it does the same thing as your code but only embedded the workguard in the ASIOLIB class. So the user wouldn't need to new a workguard by themselves.

Add WorkGuard for boost and asio libs.

The Stop() method in GenericAsioScheduler class should be calling workguard.reset() for releasing the corresponding work in the io_context object.