### PR TITLE
Added check for CMAKE_SKIP_INSTALL_RULES

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -116,34 +116,36 @@ if (CLI_BuildTests)
 endif()
 
 # Install
-install(DIRECTORY include/cli DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
+if(NOT CMAKE_SKIP_INSTALL_RULES)
+    install(DIRECTORY include/cli DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
 
-include(CMakePackageConfigHelpers)
-configure_package_config_file(
-    "cliConfig.cmake.in"
-    "${CMAKE_CURRENT_BINARY_DIR}/cliConfig.cmake"
-    INSTALL_DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/cli"
-)
+    include(CMakePackageConfigHelpers)
+    configure_package_config_file(
+        "cliConfig.cmake.in"
+        "${CMAKE_CURRENT_BINARY_DIR}/cliConfig.cmake"
+        INSTALL_DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/cli"
+    )
 
-# Generate pkg-config .pc file
-set(PKGCONFIG_INSTALL_DIR
-    ${CMAKE_INSTALL_DATAROOTDIR}/pkgconfig
-    CACHE PATH "Installation directory for pkg-config (cli.pc) file"
-)
-configure_file(
-    "cli.pc.in"
-    "cli.pc"
-    @ONLY
-)
+    # Generate pkg-config .pc file
+    set(PKGCONFIG_INSTALL_DIR
+        ${CMAKE_INSTALL_DATAROOTDIR}/pkgconfig
+        CACHE PATH "Installation directory for pkg-config (cli.pc) file"
+    )
+    configure_file(
+        "cli.pc.in"
+        "cli.pc"
+        @ONLY
+    )
 
-install(TARGETS cli EXPORT cliTargets LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR})
-install(EXPORT cliTargets FILE cliTargets.cmake NAMESPACE cli:: DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/cli)
+    install(TARGETS cli EXPORT cliTargets LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR})
+    install(EXPORT cliTargets FILE cliTargets.cmake NAMESPACE cli:: DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/cli)
 
-install(
-    FILES "${CMAKE_CURRENT_BINARY_DIR}/cliConfig.cmake"
-    DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/cli"
-)
-install(
-    FILES "${CMAKE_CURRENT_BINARY_DIR}/cli.pc"
-    DESTINATION ${PKGCONFIG_INSTALL_DIR}
-)
+    install(
+        FILES "${CMAKE_CURRENT_BINARY_DIR}/cliConfig.cmake"
+        DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/cli"
+    )
+    install(
+        FILES "${CMAKE_CURRENT_BINARY_DIR}/cli.pc"
+        DESTINATION ${PKGCONFIG_INSTALL_DIR}
+    )
+endif()


### PR DESCRIPTION
CMake's [FetchContent](https://cmake.org/cmake/help/latest/module/FetchContent.html) module allows people to include your library in their project directly without using an external library manager (ex. vcpkg or conan). Here is an example for doing that:

```cmake
include(FetchContent)
FetchContent_Declare(
  cli
  GIT_REPOSITORY https://github.com/daniele77/cli.git
  GIT_TAG v2.0.2
)
FetchContent_MakeAvailable(cli)

add_executable(main-project)
target_link_libraries(main-project PRIVATE cli::cli)
```

The only issue with using `FetchContent` is that the cli library will attempt to add install steps regardless of it is the main project or not. CMake allows you to disable the install steps by temporarily setting the `CMAKE_SKIP_INSTALL_RULES` variable to `ON`, but that makes CMake generate a nasty warning message:

```
CMake Warning in CMakeLists.txt:
  CMAKE_SKIP_INSTALL_RULES was enabled even though installation rules have
  been specified
```

This is a known issue with CMake ([issue #22561](https://gitlab.kitware.com/cmake/cmake/-/issues/22561)) which does not appear like it will be fixed anytime soon. The current fix for `FetchContent` users is to guard a library's install steps with a check for `CMAKE_SKIP_INSTALL_RULES`:

```cmake
if(NOT CMAKE_SKIP_INSTALL_RULES)
  install(...)
endif()
```

This pull request adds that check which allows the library to be integrated using `FetchContent` without having additional warning messages appear.
