### PR TITLE
Add basic support for emacs-like line editing.

### DIFF
--- a/include/cli/detail/inputdevice.h
+++ b/include/cli/detail/inputdevice.h
@@ -41,7 +41,7 @@ namespace detail
 
 enum class KeyType { ascii, up, down, left, right, backspace, canc, home, end, ret, eof,
                      transpose_chars, unix_line_discard, kill_line, unix_word_rubout,
-                     clear_screen, reverse_search_history, ignored };
+                     yank, clear_screen, reverse_search_history, ignored };
 
 class InputDevice
 {

--- a/include/cli/detail/inputdevice.h
+++ b/include/cli/detail/inputdevice.h
@@ -39,7 +39,9 @@ namespace cli
 namespace detail
 {
 
-enum class KeyType { ascii, up, down, left, right, backspace, canc, home, end, ret, eof, ignored };
+enum class KeyType { ascii, up, down, left, right, backspace, canc, home, end, ret, eof,
+                     transpose_chars, unix_line_discard, kill_line, unix_word_rubout,
+                     clear_screen, reverse_search_history, ignored };
 
 class InputDevice
 {

--- a/include/cli/detail/inputhandler.h
+++ b/include/cli/detail/inputhandler.h
@@ -118,6 +118,13 @@ private:
                 terminal.SetLine( line );
                 break;
             }
+            case Symbol::clrscr:
+            {
+                session.Prompt();
+                terminal.ResetCursor();
+                terminal.SetLine(terminal.GetLine());
+                break;
+            }
         }
 
     }

--- a/include/cli/detail/inputhandler.h
+++ b/include/cli/detail/inputhandler.h
@@ -125,6 +125,11 @@ private:
                 terminal.SetLine(terminal.GetLine());
                 break;
             }
+            case Symbol::reverse_search_history:
+            {
+                // TODO
+                break;
+            }
         }
 
     }

--- a/include/cli/detail/linuxkeyboard.h
+++ b/include/cli/detail/linuxkeyboard.h
@@ -200,6 +200,8 @@ private:
                 return std::make_pair(KeyType::kill_line,' ');
             case 23: // C-w
                 return std::make_pair(KeyType::unix_word_rubout,' ');
+            case 25: // C-y
+                return std::make_pair(KeyType::yank,' ');
             case 12: // C-l
                 return std::make_pair(KeyType::clear_screen,' ');
             case 18: // C-r

--- a/include/cli/detail/linuxkeyboard.h
+++ b/include/cli/detail/linuxkeyboard.h
@@ -153,11 +153,11 @@ private:
             case EOF:
             case 4:  // EOT
                 return std::make_pair(KeyType::eof,' ');
-                break;
             case 127:
             case 8:
-                return std::make_pair(KeyType::backspace,' '); break;
-            case 10: return std::make_pair(KeyType::ret,' '); break;
+                return std::make_pair(KeyType::backspace,' ');
+            case 10:
+                return std::make_pair(KeyType::ret,' ');
             case 27: // symbol
                 ch = GetChar();
                 if ( ch == 91 ) // arrow keys
@@ -169,7 +169,6 @@ private:
                             ch = GetChar();
                             if ( ch == 126 ) return std::make_pair(KeyType::canc,' ');
                             else return std::make_pair(KeyType::ignored,' ');
-                            break;
                         case 65: return std::make_pair(KeyType::up,' ');
                         case 66: return std::make_pair(KeyType::down,' ');
                         case 68: return std::make_pair(KeyType::left,' ');
@@ -180,6 +179,32 @@ private:
                     }
                 }
                 break;
+            // readline emacs mode line edit shortcut
+            case 1:  // C-a
+                return std::make_pair(KeyType::home,' ');
+            case 5:  // C-e
+                return std::make_pair(KeyType::end,' ');
+            case 2:  // C-b
+                return std::make_pair(KeyType::left,' ');
+            case 6:  // C-f
+                return std::make_pair(KeyType::right,' ');
+            case 14: // C-n
+                return std::make_pair(KeyType::down,' ');
+            case 16: // C-p
+                return std::make_pair(KeyType::up,' ');
+            case 20: // C-t
+                return std::make_pair(KeyType::transpose_chars,' ');
+            case 21: // C-u
+                return std::make_pair(KeyType::unix_line_discard,' ');
+            case 22: // C-k
+                return std::make_pair(KeyType::kill_line,' ');
+            case 23: // C-w
+                return std::make_pair(KeyType::unix_word_rubout,' ');
+            case 12: // C-l
+                return std::make_pair(KeyType::clear_screen,' ');
+            case 18: // C-r
+                return std::make_pair(KeyType::reverse_search_history,' ');
+
             default: // ascii
             {
                 const char c = static_cast<char>(ch);

--- a/include/cli/detail/terminal.h
+++ b/include/cli/detail/terminal.h
@@ -47,6 +47,7 @@ enum class Symbol
     down,
     tab,
     clrscr,
+    reverse_search_history,
     eof
 };
 
@@ -132,7 +133,7 @@ class Terminal
             case KeyType::transpose_chars:
             {
                 if (currentLine.size() < 2 || position == 0)
-                    // TODO: bell?
+                    // TODO: ring bell?
                     break;
                 // if position is at the end, transpose the characters before position
                 auto tr_pos = position == currentLine.size()? position-1: position;
@@ -145,32 +146,35 @@ class Terminal
                 position = tr_pos + 1;
                 break;
             }
-            case KeyType::unix_line_discard:
+            case KeyType::unix_word_rubout:
             {
                 if (position == 0)
                     break;
-
-                const auto current_len = currentLine.size();
-                // remove chars before the cursor from buffer
-                currentLine.erase(currentLine.begin(), currentLine.begin() + position);
-                // go back to the beginning of the line
-                out << std::string(position, '\b');
-                // output the rest of the line
-                out << beforeInput << currentLine << afterInput;
-                // remove rest chars
-                out << std::string(position, ' ');
-                // go back to the beginning of the line
-                out << std::string(current_len, '\b') << std::flush;
-                position = 0;
+                int kill_index = position - 1;
+                while (kill_index >= 0 && std::isspace(currentLine[kill_index]))
+                    --kill_index;
+                while (kill_index >= 0 && !std::isspace(currentLine[kill_index]))
+                    --kill_index;
+                KillText(kill_index + 1, position - kill_index - 1);
                 break;
             }
-            case KeyType::kill_line:
-                if (position == currentLine.size())
-                    break;
-                // TODO (guo)
+            case KeyType::unix_line_discard:
+                KillText(0, position);
                 break;
-            case KeyType::unix_word_rubout:
-                // TODO (guo)
+            case KeyType::kill_line:
+                KillText(position, currentLine.size() - position);
+                break;
+            case KeyType::yank:
+                // output kill buffer and the rest of the string:
+                out << beforeInput
+                    << killBuffer
+                    << std::string(currentLine.begin() + position, currentLine.end())
+                    << afterInput;
+                // go back to the original position
+                out << std::string(currentLine.size() - position, '\b') << std::flush;
+                // update the buffer and cursor position:
+                currentLine.insert(position, killBuffer);
+                position += killBuffer.size();
                 break;
             case KeyType::clear_screen:
                 // TODO: get the correct escape sequence for current terminal using tigetstr/tgetstr
@@ -179,8 +183,7 @@ class Terminal
                 // prompt and current line will be printed in NewCommand()
                 return std::make_pair(Symbol::clrscr, std::string{});
             case KeyType::reverse_search_history:
-                // TODO (guo)
-                break;
+                return std::make_pair(Symbol::reverse_search_history, currentLine);
             case KeyType::ret:
             {
                 out << "\r\n";
@@ -258,8 +261,33 @@ class Terminal
 
   private:
     std::string currentLine;
+    std::string killBuffer; // TODO: implement kill ring other than buffer
     std::size_t position = 0; // next writing position in currentLine
     std::ostream &out;
+    void KillText(const size_t index, const size_t npos)
+    {
+        if (npos == 0 || position < index) {
+            // TODO: ring bell?
+            return;
+        }
+        // go back to the beginning of the kill region
+        out << std::string(position - index, '\b');
+        // output the rest of the line
+        out << beforeInput
+            << std::string(currentLine.begin() + index + npos, currentLine.end())
+            << afterInput;
+        // remove rest chars
+        out << std::string(npos, ' ');
+        // go back to the beginning of the kill region
+        out << std::string(currentLine.size() - index, '\b') << std::flush;
+
+        // save kill region to buffer
+        killBuffer = currentLine.substr(index, npos);
+        // remove kill region
+        currentLine.erase(currentLine.begin() + index,
+                          currentLine.begin() + index + npos);
+        position = index;
+    }
 };
 
 } // namespace detail

--- a/include/cli/detail/terminal.h
+++ b/include/cli/detail/terminal.h
@@ -130,10 +130,21 @@ class Terminal
                 }
                 break;
             case KeyType::transpose_chars:
+            {
                 if (currentLine.size() < 2 || position == 0)
+                    // TODO: bell?
                     break;
-                // TODO (guo)
+                // if position is at the end, transpose the characters before position
+                auto tr_pos = position == currentLine.size()? position-1: position;
+                // XXX may not work with unicode
+                out << std::string(position - tr_pos + 1, '\b')
+                    << beforeInput
+                    << currentLine[tr_pos] << currentLine[tr_pos-1]
+                    << afterInput << std::flush;
+                std::swap(currentLine[tr_pos], currentLine[tr_pos-1]);
+                position = tr_pos + 1;
                 break;
+            }
             case KeyType::unix_line_discard:
             {
                 if (position == 0)

--- a/include/cli/detail/terminal.h
+++ b/include/cli/detail/terminal.h
@@ -46,6 +46,7 @@ enum class Symbol
     up,
     down,
     tab,
+    clrscr,
     eof
 };
 
@@ -129,7 +130,9 @@ class Terminal
                 }
                 break;
             case KeyType::transpose_chars:
-                out << afterInput << std::flush;
+                if (currentLine.size() < 2 || position == 0)
+                    break;
+                // TODO (guo)
                 break;
             case KeyType::unix_line_discard:
             {
@@ -151,12 +154,21 @@ class Terminal
                 break;
             }
             case KeyType::kill_line:
+                if (position == currentLine.size())
+                    break;
+                // TODO (guo)
                 break;
             case KeyType::unix_word_rubout:
+                // TODO (guo)
                 break;
             case KeyType::clear_screen:
-                break;
+                // TODO: get the correct escape sequence for current terminal using tigetstr/tgetstr
+                // VT100 escape sequence for clear screen ond move cursor to top left corner
+                out << "\033[H\033[2J" << std::flush;
+                // prompt and current line will be printed in NewCommand()
+                return std::make_pair(Symbol::clrscr, std::string{});
             case KeyType::reverse_search_history:
+                // TODO (guo)
                 break;
             case KeyType::ret:
             {

--- a/include/cli/detail/terminal.h
+++ b/include/cli/detail/terminal.h
@@ -126,6 +126,36 @@ class Terminal
                     ++position;
                 }
                 break;
+            case KeyType::transpose_chars:
+                out << afterInput << std::flush;
+                break;
+            case KeyType::unix_line_discard:
+            {
+                if (position == 0)
+                    break;
+
+                const auto current_len = currentLine.size();
+                // remove chars before the cursor from buffer
+                currentLine.erase(currentLine.begin(), currentLine.begin() + position);
+                // go back to the beginning of the line
+                out << std::string(position, '\b');
+                // output the rest of the line
+                out << beforeInput << currentLine << afterInput;
+                // remove rest chars
+                out << std::string(position, ' ');
+                // go back to the beginning of the line
+                out << std::string(current_len, '\b') << std::flush;
+                position = 0;
+                break;
+            }
+            case KeyType::kill_line:
+                break;
+            case KeyType::unix_word_rubout:
+                break;
+            case KeyType::clear_screen:
+                break;
+            case KeyType::reverse_search_history:
+                break;
             case KeyType::ret:
             {
                 out << "\r\n";

--- a/include/cli/detail/terminal.h
+++ b/include/cli/detail/terminal.h
@@ -97,7 +97,9 @@ class Terminal
                 // go back to the previous char
                 out << '\b';
                 // output the rest of the line
-                out << std::string(currentLine.begin() + pos, currentLine.end());
+                out << beforeInput
+                    << std::string(currentLine.begin() + pos, currentLine.end())
+                    << afterInput;
                 // remove last char
                 out << ' ';
                 // go back to the original position


### PR DESCRIPTION
Fix part of #152 by implementing some of the readline emacs mode line editing shortcuts on Linux local session and VT100 compatible terminal.

- [x] C-a move cursor to the beginning of the line
- [x] C-e move cursor to the end of the line
- [x] C-b move cursor backward
- [x] C-f move cursor forward
- [x] C-n get the next history
- [x] C-p get the previous history
- [x] C-t transpose chars
- [x] C-u unix line discard
- [x] C-k kill line
- [x] C-w unix word rubout
- [x] C-y yank (only one buffer. kill ring is not needed for now since M-y cannot be captured by read().)
- [x] C-l clear screen (only on VT100 compatible terminal)
- [ ] C-r reverse search history