### PR TITLE
bugfix: revert 0a4d8608 signed char on data reception

### DIFF
--- a/include/cli/detail/genericasioremotecli.h
+++ b/include/cli/detail/genericasioremotecli.h
@@ -173,7 +173,7 @@ protected:
     for a list of telnet options
     */
 
-    enum
+    enum : unsigned char
     {
         SE = '\x0F0',                  // End of subnegotiation parameters.
         NOP = '\x0F1',                 // No operation.
@@ -225,7 +225,7 @@ protected:
 
 private:
 
-    void Consume(signed char c)
+    void Consume(unsigned char c)
     {
         if (escape)
         {
@@ -244,7 +244,7 @@ private:
         }
     }
 
-    void Data(signed char c)
+    void Data(unsigned char c)
     {
         switch(state)
         {

--- a/include/cli/detail/linuxkeyboard.h
+++ b/include/cli/detail/linuxkeyboard.h
@@ -135,9 +135,10 @@ private:
         }
     }
 
-    char GetChar()
+    int GetChar()
     {
-        char buffer = 0;
+        // purposely cast to unsigned char to ensure in-band byte value is 0-255 before casting to int
+        unsigned char buffer = 0;
         auto unused = read(0, &buffer, 1);
         static_cast<void>(unused); // silence unused warn
         return buffer;
@@ -215,4 +216,3 @@ private:
 } // namespace cli
 
 #endif // CLI_DETAIL_LINUXKEYBOARD_H_
-


### PR DESCRIPTION
Commit 0a4d8608 caused received characters to be forcibly converted from unsigned -> signed on some platforms, and so incoming byte values >127 (such as telnet escape sequences) were getting converted to negative values. The problem is that the enum containing the escape sequence constants has wider underlying type (int) that can store the large unsigned value (such as, 0xFF). This caused telnet escape sequence comparisons to fail (such as: -128 != 255), which means that telnet escape sequence processing / filtering was not being performed.

The end result was that telnet connections close immediately upon connection (for busybox telnet client, at least).

This change standardizes on `int` as the reception/transmission char type. This allows for in-band bytes to take the values 0-255, and -1 to be used for EOF (out-of-band).  