### PR TITLE
add clear screen support with CTRL-L

### DIFF
--- a/include/cli/detail/inputdevice.h
+++ b/include/cli/detail/inputdevice.h
@@ -39,7 +39,7 @@ namespace cli
 namespace detail
 {
 
-enum class KeyType { ascii, up, down, left, right, backspace, canc, home, end, ret, eof, ignored };
+enum class KeyType { ascii, up, down, left, right, backspace, canc, home, end, ret, eof, ignored, clear, };
 
 class InputDevice
 {

--- a/include/cli/detail/inputhandler.h
+++ b/include/cli/detail/inputhandler.h
@@ -121,6 +121,12 @@ private:
                 terminal.SetLine( line );
                 break;
             }
+            case Symbol::clear:
+            {
+                session.Prompt();
+                terminal.ResetCursor();
+                break;
+            }
         }
 
     }

--- a/include/cli/detail/linuxkeyboard.h
+++ b/include/cli/detail/linuxkeyboard.h
@@ -177,6 +177,7 @@ private:
             case 8:
                 return std::make_pair(KeyType::backspace,' '); break;
             case 10: return std::make_pair(KeyType::ret,' '); break;
+            case 12: return std::make_pair(KeyType::clear, ' '); break;
             case 27: // symbol
                 ch = GetChar();
                 if ( ch == 91 ) // arrow keys

--- a/include/cli/detail/terminal.h
+++ b/include/cli/detail/terminal.h
@@ -46,7 +46,8 @@ enum class Symbol
     up,
     down,
     tab,
-    eof
+    eof,
+    clear
 };
 
 class Terminal
@@ -193,9 +194,16 @@ class Terminal
                 position = 0;
                 break;
             }
+            case KeyType::clear:
+            {
+                out << CLEAR_ESCAPE << std::flush;
+                return std::make_pair(Symbol::clear, std::string());
+                break;
+            }
             case KeyType::ignored:
                 // TODO
                 break;
+            
         }
 
         return std::make_pair(Symbol::nothing, std::string());
@@ -205,6 +213,8 @@ class Terminal
     std::string currentLine;
     std::size_t position = 0; // next writing position in currentLine
     std::ostream &out;
+    const std::string_view CLEAR_ESCAPE = "\033[H\033[J"; 
+
 };
 
 } // namespace detail

--- a/include/cli/detail/winkeyboard.h
+++ b/include/cli/detail/winkeyboard.h
@@ -160,6 +160,9 @@ private:
             case 8:
                 return std::make_pair(KeyType::backspace, c);
                 break;
+            case 12: // CTRL-L
+                return std::make_pair(KeyType::clear, ' ');
+                break;
             case 13:
                 return std::make_pair(KeyType::ret, c);
                 break;


### PR DESCRIPTION
#229 

Changes:
* add to `*keyboard.h` support for CTRL-L;
* a CTRL-L in `Terminal::Keypressed()` clears the screen by flushing the escape string on the ostream;
* after a CTRL-L, restore the session by calling `session.Prompt()`

**TODO**: add escape string for windows